### PR TITLE
fix: disable react devtools in production

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -52,6 +52,11 @@ esbuild
 		target: "es2016",
 		logLevel: "info",
 		sourcemap: !prod,
+		define: {
+			"process.env.ENABLE_REACT_DEVTOOLS": prod
+				? JSON.stringify("false")
+				: JSON.stringify("true"),
+		},
 		treeShaking: true,
 		outfile: "main.js",
 	})

--- a/src/obsidian/dashboards-view.tsx
+++ b/src/obsidian/dashboards-view.tsx
@@ -1,6 +1,9 @@
 import { TextFileView, WorkspaceLeaf } from "obsidian";
 
-import "react-devtools";
+if (process.env.ENABLE_REACT_DEVTOOLS === "true") {
+	import("react-devtools");
+}
+
 import { createRoot, Root } from "react-dom/client";
 import { store } from "src/redux/global/store";
 import { DashboardState } from "src/shared/types";

--- a/src/obsidian/editing-view-plugin.tsx
+++ b/src/obsidian/editing-view-plugin.tsx
@@ -1,7 +1,9 @@
 import { PluginValue, ViewPlugin } from "@codemirror/view";
 import { MarkdownView, TFile, WorkspaceLeaf } from "obsidian";
 
-import "react-devtools";
+if (process.env.ENABLE_REACT_DEVTOOLS === "true") {
+	import("react-devtools");
+}
 import { Root, createRoot } from "react-dom/client";
 
 import { serializeDashboardState } from "src/data/serialize-dashboard-state";

--- a/src/obsidian/reading-view-child.tsx
+++ b/src/obsidian/reading-view-child.tsx
@@ -1,6 +1,8 @@
 import { MarkdownRenderChild, TFile } from "obsidian";
 
-import "react-devtools";
+if (process.env.ENABLE_REACT_DEVTOOLS === "true") {
+	import("react-devtools");
+}
 import { Root, createRoot } from "react-dom/client";
 import { store } from "src/redux/global/store";
 import DashboardsView from "./dashboards-view";


### PR DESCRIPTION
React devtools tries to connect via websocket to a host server. SInce this is only needed in development, it should be disabled in production for users. To accomplish this, we add conditional logic around the import statement that is dependent on `process.env.ENABLE_REACT_DEVTOOLS`. This variable can be pseudo-set in the esbuild file use `define`.