### PR TITLE
Fix note with multiple embedded tables

### DIFF
--- a/src/obsidian/editing-view-plugin.tsx
+++ b/src/obsidian/editing-view-plugin.tsx
@@ -50,7 +50,7 @@ class EditingViewPlugin implements PluginValue {
 			removeEmbeddedLinkChildren(linkEl);
 
 			const file = findEmbeddedTableFile(linkEl);
-			if (!file) return;
+			if (!file) continue;
 
 			const { defaultEmbedWidth, defaultEmbedHeight } =
 				store.getState().global.settings;
@@ -65,7 +65,7 @@ class EditingViewPlugin implements PluginValue {
 
 			//If we've already created the table, then return
 			if (this.dashboardApps.find((app) => app.file.path === file.path))
-				return;
+				continue;
 
 			linkEl.style.backgroundColor = "var(--color-primary)";
 			linkEl.style.cursor = "unset";


### PR DESCRIPTION
This update will resolve the issue where you couldn't have multiple embedded tables in a file. In the logic, we iterate over all tables. If a table was already rendered we would use `return`. This would cause the function to effectively terminate. Instead we replace `return` with `continue` to make sure that the next table is iterated over