### PR TITLE
On load modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Support development
 -   [Getting started](#getting-started)
 -   [Issues](#issues)
 -   [Contributing](#contributing)
+-   [Network Usage](#network-usage)
 -   [License](#license)
 -   [Disclaimer](#disclaimer)
 
@@ -98,6 +99,12 @@ If you are experiencing a problem with the plugin, please search the issues for 
 Dashboards is a community plugin. Contributions are welcome.
 
 Please see our [contribution guide](https://github.com/trey-wallis/obsidian-dashboards/CONTRIBUTING.md) for details on how to contribute
+
+## Network Usage
+
+According to Obsidian developer policies, an Obsidian plugin must explain which network services are used and why.
+
+Dashboards will make one `GET` request to `https://api.github.com/repos/trey-wallis/obsidian-dashboards/releases/latest` to pull the lastest release for the What's New Modal. Besides this, Dashboards does not making any network requests. Dashboards does not include client-side telemetry.
 
 ## License
 

--- a/src/data/network.ts
+++ b/src/data/network.ts
@@ -1,0 +1,16 @@
+import { Notice, requestUrl } from "obsidian";
+
+export const getLastestGithubRelease = async () => {
+	try {
+		const response = await requestUrl({
+			url: "https://api.github.com/repos/trey-wallis/obsidian-dashboards/releases/latest",
+			method: "GET",
+		});
+		const body = response.json;
+		return body;
+	} catch (err) {
+		console.error(err);
+		new Notice("Error fetching latest release");
+		return null;
+	}
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import { getBasename } from "./shared/link/link-utils";
 import { hasDarkTheme } from "./shared/render/utils";
 import { removeFocusVisibleClass } from "./shared/menu/focus-visible";
 import { DashboardState } from "./shared/types";
+import WelcomeModal from "./obsidian/welcome-modal";
 
 export interface DashboardsSettings {
 	shouldDebug: boolean;
@@ -48,6 +49,7 @@ export interface DashboardsSettings {
 	defaultEmbedWidth: string;
 	defaultEmbedHeight: string;
 	hasMigratedTo700: boolean;
+	showWelcomeModal: boolean;
 }
 
 export const DEFAULT_SETTINGS: DashboardsSettings = {
@@ -58,6 +60,7 @@ export const DEFAULT_SETTINGS: DashboardsSettings = {
 	defaultEmbedWidth: "100%",
 	defaultEmbedHeight: "340px",
 	hasMigratedTo700: false,
+	showWelcomeModal: true,
 };
 
 /**
@@ -95,6 +98,12 @@ export default class DashboardsPlugin extends Plugin {
 
 			await this.migrateTableFiles();
 		});
+
+		if (this.settings.showWelcomeModal) {
+			new WelcomeModal(app).open();
+			this.settings.showWelcomeModal = false;
+			await this.saveSettings();
+		}
 	}
 
 	private async migrateTableFiles() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ import { hasDarkTheme } from "./shared/render/utils";
 import { removeFocusVisibleClass } from "./shared/menu/focus-visible";
 import { DashboardState } from "./shared/types";
 import WelcomeModal from "./obsidian/welcome-modal";
+import WhatsNewModal from "./obsidian/whats-new-modal";
 
 export interface DashboardsSettings {
 	shouldDebug: boolean;
@@ -50,6 +51,7 @@ export interface DashboardsSettings {
 	defaultEmbedHeight: string;
 	hasMigratedTo700: boolean;
 	showWelcomeModal: boolean;
+	pluginVersion: string;
 }
 
 export const DEFAULT_SETTINGS: DashboardsSettings = {
@@ -61,6 +63,7 @@ export const DEFAULT_SETTINGS: DashboardsSettings = {
 	defaultEmbedHeight: "340px",
 	hasMigratedTo700: false,
 	showWelcomeModal: true,
+	pluginVersion: "",
 };
 
 /**
@@ -102,6 +105,10 @@ export default class DashboardsPlugin extends Plugin {
 		if (this.settings.showWelcomeModal) {
 			new WelcomeModal(app).open();
 			this.settings.showWelcomeModal = false;
+			await this.saveSettings();
+		} else if (this.settings.pluginVersion !== this.manifest.version) {
+			new WhatsNewModal(this.app).open();
+			this.settings.pluginVersion = this.manifest.version;
 			await this.saveSettings();
 		}
 	}

--- a/src/obsidian/welcome-modal.tsx
+++ b/src/obsidian/welcome-modal.tsx
@@ -1,0 +1,99 @@
+import { App, Modal, setIcon } from "obsidian";
+
+export default class WelcomeModal extends Modal {
+	constructor(app: App) {
+		super(app);
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.createEl("h2", { text: "Welcome to Dashboards" });
+		contentEl.createDiv({
+			text: "Powerful dashboard suite inspired by Notion.so",
+		});
+		this.renderDivider(contentEl);
+		contentEl.createEl("h5", { text: "Learn how to use" });
+
+		const cardContainerEl = contentEl.createDiv();
+		cardContainerEl.style.display = "flex";
+		cardContainerEl.style.flexDirection = "column";
+		cardContainerEl.style.rowGap = "1rem";
+
+		this.renderCard(
+			cardContainerEl,
+			"Quick start",
+			"Learn the basics of creating a dashboard",
+			"https://trey-wallis.github.io/obsidian-dashboards/getting-started/quick-start",
+			"table"
+		);
+
+		this.renderCard(
+			cardContainerEl,
+			"Embedded dashboards",
+			"Learn how to embed a dashboard into a markdown note",
+			"https://trey-wallis.github.io/obsidian-dashboards/other/embedding-dashboards",
+			"sticky-note"
+		);
+
+		this.renderCard(
+			cardContainerEl,
+			"Keyboard focus system",
+			"Learn how to navigate dashboards with your keyboard",
+			"https://trey-wallis.github.io/obsidian-dashboards/other/keyboard-focus-system",
+			"list-plus"
+		);
+	}
+
+	renderDivider(contentEl: HTMLElement) {
+		const dividerEl = contentEl.createDiv();
+		dividerEl.style.padding = "0.75em 0";
+		dividerEl.style.borderBottom =
+			"1px solid var(--background-modifier-border)";
+	}
+
+	renderCard(
+		contentEl: HTMLElement,
+		title: string,
+		description: string,
+		link: string,
+		iconId: string
+	) {
+		//Card
+		const cardEl = contentEl.createDiv();
+		// cardEl.addEventListener("mouseover", () => {
+		// 	cardEl.style.backgroundColor = "var(--background-modifier-hover)";
+		// });
+		// cardEl.addEventListener("mouseleave", () => {
+		// 	cardEl.style.backgroundColor = "unset";
+		// });
+		cardEl.style.display = "flex";
+		cardEl.style.padding = "1em 1.5em";
+		cardEl.style.columnGap = "1.5em";
+		cardEl.style.alignItems = "center";
+		cardEl.style.border = "1px solid var(--background-modifier-border)";
+
+		const iconEl = cardEl.createDiv();
+		setIcon(iconEl, iconId);
+		(iconEl.firstChild as HTMLElement).style.width = "1.5em";
+		(iconEl.firstChild as HTMLElement).style.height = "1.5em";
+
+		//Card container
+		const cardContainerEl = cardEl.createDiv();
+
+		const titleEl = cardContainerEl.createEl("h6", { text: title });
+		titleEl.style.margin = "0";
+
+		const descriptionEl = cardContainerEl.createEl("p", {
+			text: description,
+		});
+		descriptionEl.style.marginTop = "0.25em";
+		descriptionEl.style.marginBottom = "0.5em";
+
+		cardContainerEl.createEl("a", { text: "Get started", href: link });
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
+}

--- a/src/obsidian/welcome-modal.tsx
+++ b/src/obsidian/welcome-modal.tsx
@@ -12,7 +12,9 @@ export default class WelcomeModal extends Modal {
 			text: "Powerful dashboard suite inspired by Notion.so",
 		});
 		this.renderDivider(contentEl);
-		contentEl.createEl("h5", { text: "Learn how to use" });
+		const titleEl = contentEl.createEl("h5", { text: "Learn how to use" });
+		titleEl.style.marginTop = "0em";
+		titleEl.style.marginBottom = "1em";
 
 		const cardContainerEl = contentEl.createDiv();
 		cardContainerEl.style.display = "flex";
@@ -44,14 +46,14 @@ export default class WelcomeModal extends Modal {
 		);
 	}
 
-	renderDivider(contentEl: HTMLElement) {
+	private renderDivider(contentEl: HTMLElement) {
 		const dividerEl = contentEl.createDiv();
-		dividerEl.style.padding = "0.75em 0";
-		dividerEl.style.borderBottom =
+		dividerEl.style.margin = "1.5em 0";
+		dividerEl.style.borderTop =
 			"1px solid var(--background-modifier-border)";
 	}
 
-	renderCard(
+	private renderCard(
 		contentEl: HTMLElement,
 		title: string,
 		description: string,
@@ -60,12 +62,6 @@ export default class WelcomeModal extends Modal {
 	) {
 		//Card
 		const cardEl = contentEl.createDiv();
-		// cardEl.addEventListener("mouseover", () => {
-		// 	cardEl.style.backgroundColor = "var(--background-modifier-hover)";
-		// });
-		// cardEl.addEventListener("mouseleave", () => {
-		// 	cardEl.style.backgroundColor = "unset";
-		// });
 		cardEl.style.display = "flex";
 		cardEl.style.padding = "1em 1.5em";
 		cardEl.style.columnGap = "1.5em";

--- a/src/obsidian/whats-new-modal.tsx
+++ b/src/obsidian/whats-new-modal.tsx
@@ -1,0 +1,94 @@
+import { App, Component, MarkdownRenderer, Modal } from "obsidian";
+import { getLastestGithubRelease } from "src/data/network";
+
+export default class WhatsNewModal extends Modal {
+	constructor(app: App) {
+		super(app);
+	}
+
+	async onOpen() {
+		let { contentEl } = this;
+		contentEl.createEl("h2", { text: "Dashboards - What's New" });
+		this.renderDivider(contentEl);
+		this.renderContent(contentEl);
+	}
+
+	async renderContent(contentEl: HTMLElement) {
+		const data = await getLastestGithubRelease();
+		const { body, published_at, tag_name } = data;
+		if (data) {
+			const tagEl = contentEl.createEl("h5", {
+				text: `v${tag_name}`,
+			});
+			tagEl.style.marginTop = "0.5em";
+			tagEl.style.marginBottom = "0";
+
+			const date = new Date(published_at);
+			tagEl.innerHTML += ` <span style="font-size: 0.75em; color: var(--text-muted);">(${date.toLocaleDateString()})</span>`;
+
+			const bodyEl = contentEl.createDiv();
+			const replacedText = this.replaceIssueNumbersWithLinks(body);
+			MarkdownRenderer.renderMarkdown(
+				replacedText,
+				bodyEl,
+				"",
+				new Component()
+			);
+			bodyEl.querySelectorAll("a").forEach((a) => {
+				const issueNumber = this.extractIssueNumberFromURL(a.getText());
+				if (issueNumber) {
+					a.setText(issueNumber);
+				}
+			});
+			// (bodyEl.firstChild as HTMLElement).style.paddingInlineStart =
+			// 	"20px";
+
+			contentEl.createEl("a", {
+				text: "View all releases",
+				href: "https://github.com/trey-wallis/obsidian-dashboards/releases",
+			});
+		} else {
+			contentEl.createDiv({
+				text: "Couldn't fetch latest release from GitHub.",
+			});
+		}
+	}
+
+	private renderDivider(contentEl: HTMLElement) {
+		const dividerEl = contentEl.createDiv();
+		dividerEl.style.margin = "1.5em 0";
+		dividerEl.style.borderTop =
+			"1px solid var(--background-modifier-border)";
+	}
+
+	private replaceIssueNumbersWithLinks(text: string) {
+		// Regular expression to match #<number> pattern
+		const regex = /#(\d+)/g;
+		const replacedText = text.replace(
+			regex,
+			"https://github.com/trey-wallis/obsidian-dashboards/issues/$1"
+		);
+		return replacedText;
+	}
+
+	private extractIssueNumberFromURL(text: string) {
+		// Regular expression to extract the issue number
+		const regex = /\/(\d+)$/;
+
+		// Extract the issue number from the URL
+		const matches = text.match(regex);
+
+		if (matches && matches.length > 1) {
+			// Return the extracted issue number
+			return "#" + matches[1];
+		}
+
+		// Return null if no issue number is found
+		return null;
+	}
+
+	onClose() {
+		let { contentEl } = this;
+		contentEl.empty();
+	}
+}


### PR DESCRIPTION
When the user first opens Obsidian, open a welcome modal. Then on subsequent open, if the plugin has been updated, show a what's new modal. The what's new modal will pull from the latest release info on the github repo. We add a network usage section to the docs to address this.

**Feature**
- add What's New Modal
- add Welcome Modal

**Docs**
- add Network Usage section